### PR TITLE
Hotfix GT Sport .sxd1 header extraction

### DIFF
--- a/bms/gt_lib_extract.bms
+++ b/bms/gt_lib_extract.bms
@@ -40,7 +40,7 @@ for I = 0 < FILES
   get NAME3_OFFSET long #title
   get NAME4_OFFSET long #artist
   
-  if TYPE == 0x0003 #gt sport
+  if TYPE == 0x0003 || TYPE == 0x0103 #gt sport
       string EXT1 = ".sxd1"
 
       goto DATA_OFFSET


### PR DESCRIPTION
A (presumably) late version of GT Sport updated the library file and assigned 0x0103 to each track entry, which is not covered by the script. This PR simply rectifies that.